### PR TITLE
Variable this used as a variable for reference

### DIFF
--- a/directives/htmlWork.js
+++ b/directives/htmlWork.js
@@ -12,8 +12,10 @@ directive('include', {alter: function (node, path) {
 Object.defineProperty(Number.prototype, 'times', {
     get: function () {
         return function (callback) {
+            var i;
+            var callback = this;
             var returnArray = [];
-            for (var i = 0; i < this; i++) {
+            for (i = 0; i < callback; i++) {
                 returnArray.push(callback(i))
             }
             return returnArray

--- a/directives/htmlWork.js
+++ b/directives/htmlWork.js
@@ -13,9 +13,9 @@ Object.defineProperty(Number.prototype, 'times', {
     get: function () {
         return function (callback) {
             var i;
-            var callback = this;
+            var numericValue = this;
             var returnArray = [];
-            for (i = 0; i < callback; i++) {
+            for (i = 0; i < numericValue; i++) {
                 returnArray.push(callback(i))
             }
             return returnArray


### PR DESCRIPTION
It would be better to use this (reference) as a variable rather than using it directly (According to Google styleguides).